### PR TITLE
Provide mechanism for configuring AssemblyRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Xunit Runner LinqPad
+# Xunit.Runner.LinqPad
 
-Run Xunit test within LinqPad
+Run [Xunit](https://xunit.github.io/) tests within LinqPad.
 
 ## Example
 
-```
+```csharp
 void Main()
 {
 	XunitRunner.Run(Assembly.GetExecutingAssembly());
@@ -32,3 +32,22 @@ public class Class1
 	}
 }
 ```
+
+## Configuration
+
+`XunitRunner` includes default actions that write information to the console for `OnDiscoveryComplete()`, `OnExecutionComplete()`, `OnTestFailed()`, and `OnTestSkipped()`. If you want more control over what happens for these or other events, you can pass an `Action<AssemblyRunner>` into `Run()`.
+
+Each `Action` you pass in that takes some action on the UI thread (like `Console.WriteLine()` should start with `lock (XunitRunner.Sync)` .
+
+```csharp
+void Main()
+{
+    Action<AssemblyRunner> configure = r =>
+    {
+        r.OnTestFailed = i => { lock (XunitRunner.Sync) Console.WriteLine("BIG FAIL"); };
+    };
+    
+    XunitRunner.Run(Assembly.GetExecutingAssembly(), configure);
+}
+```
+

--- a/Xunit.Runner.LinqPad.sln
+++ b/Xunit.Runner.LinqPad.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.168
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xunit.Runner.LinqPad", "Xunit.Runner.LinqPad\Xunit.Runner.LinqPad.csproj", "{9100F58B-D8AB-4501-853C-F5BE3049A6A4}"
 EndProject
@@ -18,5 +18,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BB85FE9F-F719-4732-9185-0B87809F9BA5}
 	EndGlobalSection
 EndGlobal

--- a/Xunit.Runner.LinqPad/Properties/AssemblyInfo.cs
+++ b/Xunit.Runner.LinqPad/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]


### PR DESCRIPTION
This has been a very useful library!

I've run into situations where I'm running a bunch of tests, and I don't care about the stack trace for failed tests -- I just want to be notified of which tests are failing. Adding a configuration delegate to the `Run()` method seemed like an easy and flexible way to give the user a way to customize behavior.